### PR TITLE
Use existing Generics localization strings in WHM/SCH config Draw calls

### DIFF
--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -41,7 +41,7 @@ internal partial class SCH
                     ImGui.Indent();
                     DrawRoundedSliderFloat(0, 4, SCH_ST_DPS_BioUptime_Threshold, Generics.DoTSecondsRemainingZeroDisable, digits: 1);
                     ImGui.Unindent();
-                    DrawAdditionalBoolChoice(SCH_ST_ADV_DPS_Bio_TwoTarget, "Two target dotting", "Will maintain Damage over time spells on two targets if applicable.");
+                    DrawAdditionalBoolChoice(SCH_ST_ADV_DPS_Bio_TwoTarget, Generics.TwoTargetDotting, Generics.TwoTargetDottingDescription);
                     break;
 
                 case Preset.SCH_ST_ADV_DPS_ChainStrat:
@@ -103,9 +103,9 @@ internal partial class SCH
                 case Preset.SCH_AoE_ADV_DPS_DoT:
                     DrawSliderInt(0, 100, SCH_AoE_ADV_DPS_DoT_HPThreshold, "Target HP% to stop using (0 = Use Always, 100 = Never)");
                     ImGui.Indent();
-                    DrawRoundedSliderFloat(0, 5, SCH_AoE_ADV_DPS_DoT_Reapply, "Seconds remaining before reapplying (0 = Do not reapply early)", digits: 1);
+                    DrawRoundedSliderFloat(0, 5, SCH_AoE_ADV_DPS_DoT_Reapply, Generics.StopSeconds, digits: 1);
                     ImGui.Unindent();
-                    DrawSliderInt(0, 10, SCH_AoE_ADV_DPS_DoT_MaxTargets, "Maximum number of targets to employ multi-dotting ");
+                    DrawSliderInt(0, 10, SCH_AoE_ADV_DPS_DoT_MaxTargets, Generics.MaxTargetsMultiDot);
                     break;
                 #endregion
 
@@ -123,69 +123,69 @@ internal partial class SCH
                     break;
 
                 case Preset.SCH_ST_Heal_Lustrate:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_LustrateOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_ST_Heal_LustrateOption, Generics.StopFriendlyHpPercent100);
                     DrawPriorityInput(SCH_ST_Heals_Priority, 12, 0, $"{Lustrate.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_ST_Heal_Excogitation:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_ExcogitationOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_ST_Heal_ExcogitationOption, Generics.StopFriendlyHpPercent100);
                     DrawAdditionalBoolChoice(SCH_ST_Heal_ExcogitationBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
                     DrawAdditionalBoolChoice(SCH_ST_Heal_ExcogitationTankOption, "Only on Tanks", "Will only use on a Tank.");
                     DrawPriorityInput(SCH_ST_Heals_Priority, 12, 1, $"{Excogitation.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_ST_Heal_Protraction:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_ProtractionOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_ST_Heal_ProtractionOption, Generics.StopFriendlyHpPercent100);
                     DrawAdditionalBoolChoice(SCH_ST_Heal_ProtractionBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
                     DrawAdditionalBoolChoice(SCH_ST_Heal_ProtractionTankOption, "Only on Tanks", "Will only use on a Tank.");
                     DrawPriorityInput(SCH_ST_Heals_Priority, 12, 2, $"{Protraction.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_ST_Heal_Aetherpact:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_AetherpactOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_ST_Heal_AetherpactOption, Generics.StopFriendlyHpPercent100);
                     DrawSliderInt(0, 100, SCH_ST_Heal_AetherpactDissolveOption, "Stop using when above HP %.");
                     DrawSliderInt(10, 100, SCH_ST_Heal_AetherpactFairyGauge, "Minimal Fairy Gauge to start using Aetherpact", sliderIncrement: Tens);
                     DrawPriorityInput(SCH_ST_Heals_Priority, 12, 3, $"{Aetherpact.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_ST_Heal_WhisperingDawn:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_WhisperingDawnOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_ST_Heal_WhisperingDawnOption, Generics.StopFriendlyHpPercent100);
                     DrawAdditionalBoolChoice(SCH_ST_Heal_WhisperingDawnBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
                     DrawPriorityInput(SCH_ST_Heals_Priority, 12, 5, $"{WhisperingDawn.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_ST_Heal_FeyIllumination:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_FeyIlluminationOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_ST_Heal_FeyIlluminationOption, Generics.StopFriendlyHpPercent100);
                     DrawAdditionalBoolChoice(SCH_ST_Heal_FeyIlluminationBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
                     DrawPriorityInput(SCH_ST_Heals_Priority, 12, 6, $"{FeyIllumination.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_ST_Heal_FeyBlessing:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_FeyBlessingOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_ST_Heal_FeyBlessingOption, Generics.StopFriendlyHpPercent100);
                     DrawAdditionalBoolChoice(SCH_ST_Heal_FeyBlessingBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
                     DrawPriorityInput(SCH_ST_Heals_Priority, 12, 7, $"{FeyBlessing.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_ST_Heal_Seraphism:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_SeraphismOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_ST_Heal_SeraphismOption, Generics.StopFriendlyHpPercent100);
                     DrawAdditionalBoolChoice(SCH_ST_Heal_SeraphismBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
                     DrawPriorityInput(SCH_ST_Heals_Priority, 12, 8, $"{Seraphism.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_ST_Heal_Expedient:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_ExpedientOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_ST_Heal_ExpedientOption, Generics.StopFriendlyHpPercent100);
                     DrawAdditionalBoolChoice(SCH_ST_Heal_ExpedientBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
                     DrawPriorityInput(SCH_ST_Heals_Priority, 12, 9, $"{Expedient.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_ST_Heal_SummonSeraph:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_SummonSeraphOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_ST_Heal_SummonSeraphOption, Generics.StopFriendlyHpPercent100);
                     DrawAdditionalBoolChoice(SCH_ST_Heal_SummonSeraphBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
                     DrawPriorityInput(SCH_ST_Heals_Priority, 12, 10, $"{SummonSeraph.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_ST_Heal_Consolation:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_ConsolationOption, "Start using when below HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_ST_Heal_ConsolationOption, Generics.StopFriendlyHpPercent100);
                     DrawAdditionalBoolChoice(SCH_ST_Heal_ConsolationBossOption, "Not on Bosses", "Will not use on ST in Boss encounters.");
                     DrawPriorityInput(SCH_ST_Heals_Priority, 12, 11, $"{Consolation.ActionName()} Priority: ");
                     break;
@@ -207,7 +207,7 @@ internal partial class SCH
                     break;
 
                 case Preset.SCH_ST_Heal_Esuna:
-                    DrawSliderInt(0, 100, SCH_ST_Heal_EsunaOption, "Stop using when below HP %. Set to Zero to disable this check");
+                    DrawSliderInt(0, 100, SCH_ST_Heal_EsunaOption, Generics.StopFriendlyHpPercentZero);
                     break;
 
                 #endregion
@@ -227,37 +227,37 @@ internal partial class SCH
                     break;
 
                 case Preset.SCH_AoE_Heal_WhisperingDawn:
-                    DrawSliderInt(0, 100, SCH_AoE_Heal_WhisperingDawnOption, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_AoE_Heal_WhisperingDawnOption, Generics.StartUsingWhenBelowPartyAverageHPSetTo100ToDisableThisCheck);
                     DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 0, $"{WhisperingDawn.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_AoE_Heal_FeyIllumination:
-                    DrawSliderInt(0, 100, SCH_AoE_Heal_FeyIlluminationOption, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_AoE_Heal_FeyIlluminationOption, Generics.StartUsingWhenBelowPartyAverageHPSetTo100ToDisableThisCheck);
                     DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 1, $"{FeyIllumination.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_AoE_Heal_FeyBlessing:
-                    DrawSliderInt(0, 100, SCH_AoE_Heal_FeyBlessingOption, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_AoE_Heal_FeyBlessingOption, Generics.StartUsingWhenBelowPartyAverageHPSetTo100ToDisableThisCheck);
                     DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 2, $"{FeyBlessing.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_AoE_Heal_Consolation:
-                    DrawSliderInt(0, 100, SCH_AoE_Heal_ConsolationOption, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_AoE_Heal_ConsolationOption, Generics.StartUsingWhenBelowPartyAverageHPSetTo100ToDisableThisCheck);
                     DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 3, $"{Consolation.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_AoE_Heal_SummonSeraph:
-                    DrawSliderInt(0, 100, SCH_AoE_Heal_SummonSeraph, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_AoE_Heal_SummonSeraph, Generics.StartUsingWhenBelowPartyAverageHPSetTo100ToDisableThisCheck);
                     DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 6, $"{SummonSeraph.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_AoE_Heal_Seraphism:
-                    DrawSliderInt(0, 100, SCH_AoE_Heal_SeraphismOption, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_AoE_Heal_SeraphismOption, Generics.StartUsingWhenBelowPartyAverageHPSetTo100ToDisableThisCheck);
                     DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 4, $"{Seraphism.ActionName()} Priority: ");
                     break;
 
                 case Preset.SCH_AoE_Heal_Indomitability:
-                    DrawSliderInt(0, 100, SCH_AoE_Heal_IndomitabilityOption, "Start using when below party average HP %. Set to 100 to disable this check");
+                    DrawSliderInt(0, 100, SCH_AoE_Heal_IndomitabilityOption, Generics.StartUsingWhenBelowPartyAverageHPSetTo100ToDisableThisCheck);
                     DrawAdditionalBoolChoice(SCH_AoE_Heal_Indomitability_Recitation, "Recitation Option", "Will use Recitation to buff Indomitability.");
                     DrawPriorityInput(SCH_AoE_Heals_Priority, 8, 5, $"{Indomitability.ActionName()} Priority: ");
                     break;
@@ -314,8 +314,8 @@ internal partial class SCH
                     break;
 
                 case Preset.SCH_Retarget_SacredSoil:
-                    DrawHorizontalMultiChoice(SCH_Retarget_SacredSoilOptions, "Enemy Hard Target", "Will place under hard target if it is an Enemy.", 2, 0);
-                    DrawHorizontalMultiChoice(SCH_Retarget_SacredSoilOptions, "Ally Hard Target", "Will place under hard target if it is an Ally.", 2, 1);
+                    DrawHorizontalMultiChoice(SCH_Retarget_SacredSoilOptions, Generics.EnemyHardTarget, "Will place under hard target if it is an Enemy.", 2, 0);
+                    DrawHorizontalMultiChoice(SCH_Retarget_SacredSoilOptions, Generics.AllyHardTarget, "Will place under hard target if it is an Ally.", 2, 1);
                     break;
 
                 case Preset.SCH_Mit_ST:

--- a/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
+++ b/WrathCombo/Combos/PvE/WHM/WHM_Config.cs
@@ -48,7 +48,7 @@ internal partial class WHM
                     ImGui.Indent();
                     DrawRoundedSliderFloat(0, 4, WHM_ST_DPS_AeroUptime_Threshold, Generics.DoTSecondsRemainingZeroDisable, digits: 1);
                     ImGui.Unindent();
-                    DrawAdditionalBoolChoice(WHM_ST_MainCombo_DoT_TwoTarget, "Two target dotting", "Will maintain Damage over time spells on two targets if applicable.");
+                    DrawAdditionalBoolChoice(WHM_ST_MainCombo_DoT_TwoTarget, Generics.TwoTargetDotting, Generics.TwoTargetDottingDescription);
                     break;
 
                 case Preset.WHM_ST_MainCombo_Misery:
@@ -85,7 +85,7 @@ internal partial class WHM
                         itemWidth: little, digits: 1);
                     ImGui.Unindent();
                     DrawSliderInt(0, 10, WHM_AoE_MainCombo_DoT_MaxTargets,
-                        "Maximum number of targets to employ multi-dotting ");
+                        Generics.MaxTargetsMultiDot);
                     break;
 
                 case Preset.WHM_AoE_DPS_Misery:
@@ -103,7 +103,7 @@ internal partial class WHM
 
                 case Preset.WHM_STHeals:
                     DrawAdditionalBoolChoice(WHM_STHeals_IncludeShields,
-                        "Include Shields in HP Percent Sliders",
+                        Generics.IncludeShields,
                         "");
                     break;
 
@@ -141,9 +141,9 @@ internal partial class WHM
                     break;
 
                 case Preset.WHM_STHeals_Aquaveil:
-                    DrawHorizontalMultiChoice(WHM_STHeals_AquaveilOptions,"Only Weave", weaveDescription, 3, 0);
+                    DrawHorizontalMultiChoice(WHM_STHeals_AquaveilOptions,Generics.OnlyWeave, weaveDescription, 3, 0);
                     DrawHorizontalMultiChoice(WHM_STHeals_AquaveilOptions,"Not On Bosses", nonBossesDescription, 3, 1);
-                    DrawHorizontalMultiChoice(WHM_STHeals_AquaveilOptions,"Tanks Only", "Only on Tanks", 3, 2);
+                    DrawHorizontalMultiChoice(WHM_STHeals_AquaveilOptions,Generics.TanksOnly, "Only on Tanks", 3, 2);
                     DrawSliderInt(1, 100, WHM_STHeals_AquaveilHP,
                         targetStartUsingAtDescription);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 3,
@@ -174,7 +174,7 @@ internal partial class WHM
                 case Preset.WHM_STHeals_Temperance:
                     DrawSliderInt(1, 100, WHM_STHeals_TemperanceHP,
                         targetStartUsingAtDescription);
-                    DrawHorizontalMultiChoice(WHM_STHeals_TemperanceOptions,"Only Weave", weaveDescription, 2, 0);
+                    DrawHorizontalMultiChoice(WHM_STHeals_TemperanceOptions,Generics.OnlyWeave, weaveDescription, 2, 0);
                     DrawHorizontalMultiChoice(WHM_STHeals_TemperanceOptions,"Not On Bosses", nonBossesDescription, 2, 1);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 6,
                         $"{Temperance.ActionName()} Priority: ");
@@ -183,7 +183,7 @@ internal partial class WHM
                 case Preset.WHM_STHeals_Asylum:
                     DrawSliderInt(1, 100, WHM_STHeals_AsylumHP,
                         targetStartUsingAtDescription);
-                    DrawHorizontalMultiChoice(WHM_STHeals_AsylumOptions,"Only Weave", weaveDescription, 2, 0);
+                    DrawHorizontalMultiChoice(WHM_STHeals_AsylumOptions,Generics.OnlyWeave, weaveDescription, 2, 0);
                     DrawHorizontalMultiChoice(WHM_STHeals_AsylumOptions,"Not On Bosses", nonBossesDescription, 2, 1);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 7,
                         $"{Asylum.ActionName()} Priority: ");
@@ -192,7 +192,7 @@ internal partial class WHM
                 case Preset.WHM_STHeals_LiturgyOfTheBell:
                     DrawSliderInt(1, 100, WHM_STHeals_LiturgyOfTheBellHP,
                         targetStartUsingAtDescription);
-                    DrawHorizontalMultiChoice(WHM_STHeals_LiturgyOfTheBellOptions,"Only Weave", weaveDescription, 2, 0);
+                    DrawHorizontalMultiChoice(WHM_STHeals_LiturgyOfTheBellOptions,Generics.OnlyWeave, weaveDescription, 2, 0);
                     DrawHorizontalMultiChoice(WHM_STHeals_LiturgyOfTheBellOptions,"Not On Bosses", nonBossesDescription, 2, 1);
                     DrawPriorityInput(WHM_ST_Heals_Priority, 9, 8,
                         $"{LiturgyOfTheBell.ActionName()} Priority: ");
@@ -355,9 +355,9 @@ internal partial class WHM
                     ImGui.TextColored(ImGuiColors.DalamudGrey, "Options to try to Retarget Asylum to before Self:");
                     ImGui.Unindent();
                     DrawHorizontalMultiChoice(WHM_AsylumOptions,
-                        "Enemy Hard Target", "Will place at hard target if enemy", 3, 0);
+                        Generics.EnemyHardTarget, "Will place at hard target if enemy", 3, 0);
                     DrawHorizontalMultiChoice(WHM_AsylumOptions,
-                        "Ally Hard Target", "Will place at hard target if ally", 3, 1);
+                        Generics.AllyHardTarget, "Will place at hard target if ally", 3, 1);
                     break;
 
                 case Preset.WHM_Re_LiturgyOfTheBell:
@@ -365,9 +365,9 @@ internal partial class WHM
                     ImGui.TextColored(ImGuiColors.DalamudGrey, "Options to try to Retarget Liturgy of the Bell to before Self:");
                     ImGui.Unindent();
                     DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,
-                        "Enemy Hard Target", "Will place at hard target if enemy", 2, 0);
+                        Generics.EnemyHardTarget, "Will place at hard target if enemy", 2, 0);
                     DrawHorizontalMultiChoice(WHM_LiturgyOfTheBellOptions,
-                        "Ally Hard Target", "Will place at hard target if ally", 2, 1);
+                        Generics.AllyHardTarget, "Will place at hard target if ally", 2, 1);
                     break;
 
 
@@ -405,7 +405,7 @@ internal partial class WHM
 
         /// Description for reapplication of Buff/DoT time remaining
         private const string reapplyTimeRemainingDescription =
-            "Seconds remaining before reapplying (0 = Do not reapply early)";
+            Generics.StopSeconds;
 
         /// Description for charges to keep
         private const string chargesToKeepDescription =
@@ -413,7 +413,7 @@ internal partial class WHM
 
         /// Description for only weaving
         private const string weaveDescription =
-            "Only Weave";
+            Generics.OnlyWeave;
 
         private const string nonBossesDescription =
             "Will not use on ST in Boss encounters.";


### PR DESCRIPTION
### Motivation
- Replace remaining hardcoded UI strings in config `Draw` functions with existing localized entries to improve consistency and prepare for multi-language support.
- This is a localization-only refactor that should not change runtime behavior of UI code. 

### Description
- Replaced hardcoded labels/descriptions in `WrathCombo/Combos/PvE/WHM/WHM_Config.cs` with `Generics` resource properties such as `TwoTargetDotting`, `TwoTargetDottingDescription`, `MaxTargetsMultiDot`, `IncludeShields`, `OnlyWeave`, `TanksOnly`, `EnemyHardTarget`, `AllyHardTarget`, and `StopSeconds`.
- Replaced hardcoded labels/descriptions in `WrathCombo/Combos/PvE/SCH/SCH_Config.cs` with `Generics` resource properties including `TwoTargetDotting`, `DoT` reapply/stop text (`StopSeconds`/`MaxTargetsMultiDot`), repeated ST/AoE HP descriptions (`StopFriendlyHpPercent100`, `StopFriendlyHpPercentZero`, `StartUsingWhenBelowPartyAverageHPSetTo100ToDisableThisCheck`), and retarget labels (`EnemyHardTarget`, `AllyHardTarget`).
- Kept existing helper calls and parameter ordering unchanged so behavior remains the same; this is a textual substitution to use `WrathCombo.Resources.Localization.JobConfigs.Generics` entries.
- Files modified: `WrathCombo/Combos/PvE/WHM/WHM_Config.cs` and `WrathCombo/Combos/PvE/SCH/SCH_Config.cs`.

### Testing
- Ran a Python validation script that scanned the two modified files for any remaining exact `Generics.resx` literal matches, and it reported success (no remaining exact matches). 
- Attempted to run `dotnet build WrathCombo.sln` but it failed in this environment because `dotnet` is not available. 
- Verified changes were staged and committed locally; no runtime/build verification could be performed in this environment due to the missing `dotnet` tool.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7f2c1ecf48329b713764c6c342607)