### PR TITLE
Use action constants for config UI labels in SCH/RDM/BRD

### DIFF
--- a/WrathCombo/Combos/PvE/BRD/BRD_Config.cs
+++ b/WrathCombo/Combos/PvE/BRD/BRD_Config.cs
@@ -136,17 +136,17 @@ internal partial class BRD
 
                 #region Standalone
                 case Preset.BRD_StraightShotUpgrade_OGCDs:
-                    DrawHorizontalMultiChoice(BRD_StraightShotUpgrade_OGCDs_Options, "Empyreal Arrow", "Adds Empyreal Arrow", 4, 0);
-                    DrawHorizontalMultiChoice(BRD_StraightShotUpgrade_OGCDs_Options, "Pitch Perfect", "Adds Pitch Perfect", 4, 1);
-                    DrawHorizontalMultiChoice(BRD_StraightShotUpgrade_OGCDs_Options, "Bloodletter", "Adds Bloodletter when at max charges", 4, 2);
-                    DrawHorizontalMultiChoice(BRD_StraightShotUpgrade_OGCDs_Options, "Sidewinder", "Adds Sidewinder", 4, 3);
+                    DrawHorizontalMultiChoice(BRD_StraightShotUpgrade_OGCDs_Options, EmpyrealArrow.ActionName(), "Adds Empyreal Arrow", 4, 0);
+                    DrawHorizontalMultiChoice(BRD_StraightShotUpgrade_OGCDs_Options, PitchPerfect.ActionName(), "Adds Pitch Perfect", 4, 1);
+                    DrawHorizontalMultiChoice(BRD_StraightShotUpgrade_OGCDs_Options, Bloodletter.ActionName(), "Adds Bloodletter when at max charges", 4, 2);
+                    DrawHorizontalMultiChoice(BRD_StraightShotUpgrade_OGCDs_Options, Sidewinder.ActionName(), "Adds Sidewinder", 4, 3);
                     break;
 
                 case Preset.BRD_WideVolleyUpgrade_OGCDs:
-                    DrawHorizontalMultiChoice(BRD_WideVolleyUpgrade_OGCDs_Options, "Empyreal Arrow", "Adds Empyreal Arrow", 4, 0);
-                    DrawHorizontalMultiChoice(BRD_WideVolleyUpgrade_OGCDs_Options, "Pitch Perfect", "Adds Pitch Perfect", 4, 1);
-                    DrawHorizontalMultiChoice(BRD_WideVolleyUpgrade_OGCDs_Options, "Rain Of Death", "Adds Rain of Death when at max charges, or bloodletter below level.", 4, 2);
-                    DrawHorizontalMultiChoice(BRD_WideVolleyUpgrade_OGCDs_Options, "Sidewinder", "Adds Sidewinder", 4, 3);
+                    DrawHorizontalMultiChoice(BRD_WideVolleyUpgrade_OGCDs_Options, EmpyrealArrow.ActionName(), "Adds Empyreal Arrow", 4, 0);
+                    DrawHorizontalMultiChoice(BRD_WideVolleyUpgrade_OGCDs_Options, PitchPerfect.ActionName(), "Adds Pitch Perfect", 4, 1);
+                    DrawHorizontalMultiChoice(BRD_WideVolleyUpgrade_OGCDs_Options, RainOfDeath.ActionName(), "Adds Rain of Death when at max charges, or bloodletter below level.", 4, 2);
+                    DrawHorizontalMultiChoice(BRD_WideVolleyUpgrade_OGCDs_Options, Sidewinder.ActionName(), "Adds Sidewinder", 4, 3);
                     break;
 
                 case Preset.BRD_IronJaws:

--- a/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
+++ b/WrathCombo/Combos/PvE/RDM/RDM_Config.cs
@@ -195,12 +195,12 @@ internal partial class RDM
 
                 #region Standalones
                 case Preset.RDM_Riposte_Weaves:
-                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options, "Fleche", "Adds to the OGCD button", 6, 0);
-                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options, "Contre Sixte", "Adds to the OGCD button", 6, 1);
-                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options, "Vice Of Thorns", "Adds to the OGCD button", 6, 2);
-                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options, "Prefulgence", "Adds to the OGCD button", 6, 3);
-                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options, "Engagement", "Adds to the OGCD button", 6, 4);
-                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options, "Corps-a-corps", "Adds to the OGCD button", 6, 5);
+                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options, Fleche.ActionName(), "Adds to the OGCD button", 6, 0);
+                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options, ContreSixte.ActionName(), "Adds to the OGCD button", 6, 1);
+                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options, ViceOfThorns.ActionName(), "Adds to the OGCD button", 6, 2);
+                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options, Prefulgence.ActionName(), "Adds to the OGCD button", 6, 3);
+                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options, Engagement.ActionName(), "Adds to the OGCD button", 6, 4);
+                    DrawHorizontalMultiChoice(RDM_Riposte_Weaves_Options, Corpsacorps.ActionName(), "Adds to the OGCD button", 6, 5);
 
                     if (RDM_Riposte_Weaves_Options[4])
                     {
@@ -215,12 +215,12 @@ internal partial class RDM
                     break;
 
                 case Preset.RDM_Moulinet_Weaves:
-                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options, "Fleche", "Adds to the OGCD button", 6, 0);
-                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options, "Contre Sixte", "Adds to the OGCD button", 6, 1);
-                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options, "Vice Of Thorns", "Adds to the OGCD button", 6, 2);
-                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options, "Prefulgence", "Adds to the OGCD button", 6, 3);
-                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options, "Engagement", "Adds to the OGCD button", 6, 4);
-                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options, "Corps-a-corps", "Adds to the OGCD button", 6, 5);
+                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options, Fleche.ActionName(), "Adds to the OGCD button", 6, 0);
+                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options, ContreSixte.ActionName(), "Adds to the OGCD button", 6, 1);
+                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options, ViceOfThorns.ActionName(), "Adds to the OGCD button", 6, 2);
+                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options, Prefulgence.ActionName(), "Adds to the OGCD button", 6, 3);
+                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options, Engagement.ActionName(), "Adds to the OGCD button", 6, 4);
+                    DrawHorizontalMultiChoice(RDM_Moulinet_Weaves_Options, Corpsacorps.ActionName(), "Adds to the OGCD button", 6, 5);
 
                     if (RDM_Moulinet_Weaves_Options[4])
                     {
@@ -245,11 +245,11 @@ internal partial class RDM
                     break;
 
                 case Preset.RDM_OGCDs:
-                    DrawHorizontalMultiChoice(RDM_OGCDs_Options, "Contre Sixte", "Adds to the OGCD button", 5, 0);
-                    DrawHorizontalMultiChoice(RDM_OGCDs_Options, "Vice Of Thorns", "Adds to the OGCD button", 5, 1);
-                    DrawHorizontalMultiChoice(RDM_OGCDs_Options, "Prefulgence", "Adds to the OGCD button", 5, 2);
-                    DrawHorizontalMultiChoice(RDM_OGCDs_Options, "Engagement", "Adds to the OGCD button", 5, 3);
-                    DrawHorizontalMultiChoice(RDM_OGCDs_Options, "Corps-a-corps", "Adds to the OGCD button", 5, 4);
+                    DrawHorizontalMultiChoice(RDM_OGCDs_Options, ContreSixte.ActionName(), "Adds to the OGCD button", 5, 0);
+                    DrawHorizontalMultiChoice(RDM_OGCDs_Options, ViceOfThorns.ActionName(), "Adds to the OGCD button", 5, 1);
+                    DrawHorizontalMultiChoice(RDM_OGCDs_Options, Prefulgence.ActionName(), "Adds to the OGCD button", 5, 2);
+                    DrawHorizontalMultiChoice(RDM_OGCDs_Options, Engagement.ActionName(), "Adds to the OGCD button", 5, 3);
+                    DrawHorizontalMultiChoice(RDM_OGCDs_Options, Corpsacorps.ActionName(), "Adds to the OGCD button", 5, 4);
 
                     if (RDM_OGCDs_Options[3])
                     {
@@ -265,28 +265,28 @@ internal partial class RDM
 
                 case Preset.RDM_VerAero:
                     DrawHorizontalMultiChoice(RDM_VerAero_Options, "Holy Flare Combo", "Adds smart Holy/Flare", 4, 0);
-                    DrawHorizontalMultiChoice(RDM_VerAero_Options, "VerStone", "Adds VerStone", 4, 1);
+                    DrawHorizontalMultiChoice(RDM_VerAero_Options, Verstone.ActionName(), "Adds VerStone", 4, 1);
                     DrawHorizontalMultiChoice(RDM_VerAero_Options, "Scorch Combo", "Adds Scorch/Resolution Finishers", 4, 2);
-                    DrawHorizontalMultiChoice(RDM_VerAero_Options, "Jolt", "Adds Jolt", 4, 3);
+                    DrawHorizontalMultiChoice(RDM_VerAero_Options, Jolt.ActionName(), "Adds Jolt", 4, 3);
                     break;
 
                 case Preset.RDM_VerThunder:
                     DrawHorizontalMultiChoice(RDM_VerThunder_Options, "Holy Flare Combo", "Adds smart Holy/Flare", 4, 0);
-                    DrawHorizontalMultiChoice(RDM_VerThunder_Options, "VerFire", "Adds VerFire", 4, 1);
+                    DrawHorizontalMultiChoice(RDM_VerThunder_Options, Verfire.ActionName(), "Adds VerFire", 4, 1);
                     DrawHorizontalMultiChoice(RDM_VerThunder_Options, "Scorch Combo", "Adds Scorch/Resolution Finishers", 4, 2);
-                    DrawHorizontalMultiChoice(RDM_VerThunder_Options, "Jolt", "Adds Jolt", 4, 3);
+                    DrawHorizontalMultiChoice(RDM_VerThunder_Options, Jolt.ActionName(), "Adds Jolt", 4, 3);
                     break;
 
                 case Preset.RDM_VerAero2:
                     DrawHorizontalMultiChoice(RDM_VerAero2_Options, "Holy Flare Combo", "Adds smart Holy/Flare", 3, 0);
                     DrawHorizontalMultiChoice(RDM_VerAero2_Options, "Scorch Combo", "Adds Scorch/Resolution Finishers", 3, 1);
-                    DrawHorizontalMultiChoice(RDM_VerAero2_Options, "Impact", "Adds Impact", 3, 2);
+                    DrawHorizontalMultiChoice(RDM_VerAero2_Options, Impact.ActionName(), "Adds Impact", 3, 2);
                     break;
 
                 case Preset.RDM_VerThunder2:
                     DrawHorizontalMultiChoice(RDM_VerThunder2_Options, "Holy Flare Combo", "Adds smart Holy/Flare", 3, 0);
                     DrawHorizontalMultiChoice(RDM_VerThunder2_Options, "Scorch Combo", "Adds Scorch/Resolution Finishers", 3, 1);
-                    DrawHorizontalMultiChoice(RDM_VerThunder2_Options, "Impact", "Adds Impact", 3, 2);
+                    DrawHorizontalMultiChoice(RDM_VerThunder2_Options, Impact.ActionName(), "Adds Impact", 3, 2);
                     break;
                     #endregion
             }

--- a/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
+++ b/WrathCombo/Combos/PvE/SCH/SCH_Config.cs
@@ -304,10 +304,10 @@ internal partial class SCH
                     break;
 
                 case Preset.SCH_Recitation:
-                    DrawRadioButton(SCH_Recitation_Mode, "Adloquium", "", 0);
-                    DrawRadioButton(SCH_Recitation_Mode, "Succor", "", 1);
-                    DrawRadioButton(SCH_Recitation_Mode, "Indomitability", "", 2);
-                    DrawRadioButton(SCH_Recitation_Mode, "Excogitation", "", 3);
+                    DrawRadioButton(SCH_Recitation_Mode, Adloquium.ActionName(), "", 0);
+                    DrawRadioButton(SCH_Recitation_Mode, Succor.ActionName(), "", 1);
+                    DrawRadioButton(SCH_Recitation_Mode, Indomitability.ActionName(), "", 2);
+                    DrawRadioButton(SCH_Recitation_Mode, Excogitation.ActionName(), "", 3);
                     break;
 
                 case Preset.SCH_Raidwide_Succor:
@@ -320,16 +320,16 @@ internal partial class SCH
                     break;
 
                 case Preset.SCH_Mit_ST:
-                    DrawHorizontalMultiChoice(SCH_Mit_STOptions, "Recitation", "Will Recitation before Adloquium if available.", 3, 0);
-                    DrawHorizontalMultiChoice(SCH_Mit_STOptions, "Deployment Tactics", "Will spread Adloquium crit shield if available.", 3, 1);
-                    DrawHorizontalMultiChoice(SCH_Mit_STOptions, "Excogitation", "Will use Excogitation if available.", 3, 2);
+                    DrawHorizontalMultiChoice(SCH_Mit_STOptions, Recitation.ActionName(), "Will Recitation before Adloquium if available.", 3, 0);
+                    DrawHorizontalMultiChoice(SCH_Mit_STOptions, DeploymentTactics.ActionName(), "Will spread Adloquium crit shield if available.", 3, 1);
+                    DrawHorizontalMultiChoice(SCH_Mit_STOptions, Excogitation.ActionName(), "Will use Excogitation if available.", 3, 2);
                     break;
 
                 case Preset.SCH_Mit_AoE:
-                    DrawHorizontalMultiChoice(SCH_Mit_AoEOptions, "Fey Illumination", "Will activate Fey Illumination before Succor", 4, 0);
+                    DrawHorizontalMultiChoice(SCH_Mit_AoEOptions, FeyIllumination.ActionName(), "Will activate Fey Illumination before Succor", 4, 0);
                     DrawHorizontalMultiChoice(SCH_Mit_AoEOptions, "Crit Adloquium Deployment", "Will Recitation into Adloquium and Deployment tactics in place of Succor" +
                         "\nThis will be targeted at yourself for simplicity and reliability.", 4, 1);
-                    DrawHorizontalMultiChoice(SCH_Mit_AoEOptions, "Expedient", "Will use Expedient if available.", 4, 2);
+                    DrawHorizontalMultiChoice(SCH_Mit_AoEOptions, Expedient.ActionName(), "Will use Expedient if available.", 4, 2);
                     DrawHorizontalMultiChoice(SCH_Mit_AoEOptions, "Summon Seraph Consolation", "Will summon Seraph if available and use Consolation for more shield.", 4, 3);
                     break;
 


### PR DESCRIPTION
### Motivation
- Reduce hardcoded action-name string literals in `_Config.cs` UI builders to keep displayed labels consistent with action constants and avoid drift during refactors or localization changes.
- Replace manual strings like "Expedient" and "Fey Illumination" with the source-of-truth `ActionConstant.ActionName()` calls so UI text follows the same naming used elsewhere in the codebase.

### Description
- Replaced string literal action labels with `.ActionName()` calls in Scholar, Red Mage, and Bard config UIs, changing the displayed labels to derive from the action constants instead of hardcoded text.
- Files modified: `WrathCombo/Combos/PvE/SCH/SCH_Config.cs`, `WrathCombo/Combos/PvE/RDM/RDM_Config.cs`, and `WrathCombo/Combos/PvE/BRD/BRD_Config.cs`.
- SCH: updated Recitation radio options and mitigation multi-choice labels (including `Recitation`, `DeploymentTactics`, `Excogitation`, `FeyIllumination`, and `Expedient`).
- RDM/BRD: updated weave/OGCD option labels to use `Fleche`, `ContreSixte`, `ViceOfThorns`, `Prefulgence`, `Corpsacorps`, `Verstone`, `Verfire`, `Jolt`, `Impact`, `EmpyrealArrow`, `PitchPerfect`, `Bloodletter`, `Sidewinder`, and `RainOfDeath` via `.ActionName()`.

### Testing
- Verified the replacements by searching for `ActionName()` occurrences with `rg` and inspecting the modified regions in the three config files, which showed the new `*.ActionName()` usages.
- Ran a targeted Python replacement script to perform the edits and confirmed diffs with `git diff` to ensure only intended lines were changed.
- Attempted `dotnet build WrathCombo/WrathCombo.csproj` to validate compilation but the environment lacks `dotnet`, so a full compile check could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c84546e81c8329842fec74f8851a8e)